### PR TITLE
!feat: Make range into an iterator and make it generic

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # range
 
-Functionality of Python's `range()` in V.
+Numeric ranges in V.
 
 ## Why
 
@@ -11,12 +11,13 @@ Functionality of Python's `range()` in V.
 
 ## Features
 
-- Make `range` arrays easily
+- Make `range` easily
 - Make ranges for `int` and `f32`
-- Positive as well as Negative Support!
+- Positive as well as negative support!
 - No need to write the whole for loop! (*this maybe slower than the normal one*)
 - Use `range` for functional programming
-- Full Python's `range()` functionality
+- Support iterators. Long ranges without high memory allocation.
+- Half open-open ranges `[from,to]`
 
 ## Installation
 
@@ -29,72 +30,71 @@ Functionality of Python's `range()` in V.
 
 ## Usage
 
-- `range.int(start:0, stop:value, step:1)` 
-  makes a range of `int` with the following parameters:
-  - `start`: `start` value of the range *by default it's 0*
-  - `stop`: `stop` value of the range
-  - `step`: `step` value of the range *by default it's 1*
-
-- `range.float(start:0.0, stop:value, step:1.0)` makes a range of `f32` with the following parameters:
-  - `start`: `start` value of the range *by default it's 0.0*
-  - `stop`: `stop` value of the range
-  - `step`: `step` value of the range *by default it's 1.0*
-
-**Note**: If `range.int(step:0)` or `range.float(step:0)` then an error will be raised because `step` cannot be zero.
-
-In `main.v`
+Use an iterator if you need a large range but don't want to allocate space in memory for all numbers in the range.
 
 ```v
 import delta456.range
 
-fn main() {
-    // using range.int
-    for i in range.int(stop:10) {
-        println(i)
-    }
-
-    for i in range.int(start:1, stop:10) {
-        println(i)
-    }
-
-    for i in range.int(start:1, stop:10, step:2) {
-        println(i)
-    }
-
-    for i in range.int(start:10, stop:1, step:-1) {
-        println(i)
-    }
-
-    for i in range.int(start:-5, stop:-1, step: 1) {
-        println(i)
-    }
-
-    // using range.float
-    for i in range.float(stop:10) {
-        println(i)
-    }
-
-    for i in range.float(stop:10, step:0.2) {
-        println(i)
-    }
-
-    for i in range.float(start:0.1, stop:10) {
-        println(i)
-    }
-
-    for i in range.float(start:10, stop:1.0, step:-0.2) {
-        println(i)
-    }
-
-    for i in range.float(start:-10, stop:-1.0, step:0.2) {
-        println(i)
-    }
+mut iter := range.to_iterator(from: 0, to: 1000000, step: 2)
+for v in iter {
+  println(v)
 }
 ```
 
-## Acknowledgments
+```
+$ v run main.v
+0
+2
+4
+```
 
-I thank [@Hungry Blue Dev](https://github.com/hungrybluedev) for giving me the idea of using a `struct` with default parameters so that `range` function for each type can be the same.
+Use an array when you need it and the memory allocation for all values in the range is not a problem.
+
+```v
+import delta456.range
+
+arr := range.to_array(from: 10, to: 0, step: -1)
+println(arr)
+```
+
+```
+v run main.v
+[10, 9, 8, 7, 6, 5, 4, 3, 2, 1]
+```
+
+If you prefer you can use the builder syntax.
+
+```v
+mut iter := range.new[int]().from(0).to(10).step(1).to_iterator()insinstall/
+
+// or
+
+arr := range.new[int]().from(0).to(10).step(1).to_array()
+
+// or
+
+mut iter := range.Builder[int]{ from: 0, to: 10, step: 1 }.to_iterator()
+
+// or
+
+arr := range.Builder[int]{ from: 0, to: 10, step: 1 }.to_array()
+```
+
+The builder is immutable! You can reuse it as many times as you want.
+
+```v
+zero_to_nine := range.new[int]().from(0).to(10).step(1)
+
+// print from 0 to 9
+for v in zero_to_nine.to_iterator() {
+  println(v)
+}
+
+// print from 0 to 9 again, no problems
+for v in zero_to_nine.to_iterator() {
+  println(v)
+}
+```
 
 ## License
 

--- a/range.v
+++ b/range.v
@@ -47,7 +47,7 @@ pub fn (t Builder[T]) step(v T) Builder[T] {
 	}
 }
 
-pub fn (t Builder[T]) iterator() Range[T] {
+pub fn (t Builder[T]) to_iterator() Range[T] {
 	return Range[T]{
 		limit: t.to
 		step: t.step
@@ -55,9 +55,9 @@ pub fn (t Builder[T]) iterator() Range[T] {
 	}
 }
 
-pub fn (t Builder[T]) array() []T {
+pub fn (t Builder[T]) to_array() []T {
 	mut res := []T{}
-	mut it := t.iterator()
+	mut it := t.to_iterator()
 	for v in it {
 		res << v
 	}

--- a/range.v
+++ b/range.v
@@ -67,3 +67,11 @@ pub fn (t Builder[T]) to_array() []T {
 pub fn new[T]() Builder[T] {
 	return Builder[T]{}
 }
+
+pub fn to_array[T](builder Builder[T]) []T {
+	return builder.to_array()
+}
+
+pub fn to_iterator[T](builder Builder[T]) Range[T] {
+	return builder.to_iterator()
+}

--- a/range.v
+++ b/range.v
@@ -1,53 +1,39 @@
 module range
 
-pub struct IntRange {
-	start int = 0
-	stop  int
-	step  int = 1
+pub struct Range[T] {
+	limit T
+	step  T
+mut:
+	curr T
 }
 
-pub struct FloatRange {
-	start f32 = 1.0
-	stop  f32
-	step  f32 = 1.0
+fn (mut t Range[T]) next[T]() ?T {
+	if (t.step > 0 && t.curr >= t.limit) || (t.step < 0 && t.curr <= t.limit) {
+		return none
+	}
+	res := t.curr
+	t.curr += t.step
+	return res
 }
 
-pub fn int(range IntRange) []int {
-	mut arr := []int{}
-	if range.step == 0 {
-		eprintln('range: step cannot be zero')
-		exit(1)
+pub fn (mut t Range[T]) to_array[T]() []T {
+	mut res := []T{}
+	for v in t {
+		res << v
 	}
-	if range.start > range.stop {
-		if range.step <= -1 {
-			for i := range.start; i > range.stop; i += range.step {
-				arr << i
-			}
-		}
-	}
-	for i := range.start; i < range.stop; i += range.step {
-		arr << i
-	}
-	return arr
+	return res
 }
 
-pub fn float(float FloatRange) []f32 {
-	mut arr := []f32{}
-	if float.step == 0 {
-		eprintln('range: step cannot be zero')
-		exit(1)
+pub struct RangeOptions[T] {
+	start T
+	stop  T
+	step  T
+}
+
+pub fn range[T](opts RangeOptions[T]) Range[T] {
+	return Range[T]{
+		limit: opts.stop
+		step: opts.step
+		curr: opts.start
 	}
-	if float.start > float.stop {
-		if float.step > 0 {
-			eprintln('range: negative float step provided')
-			exit(1)
-		}
-		for i := float.start; i > float.stop; i += float.step {
-			arr << i
-		}
-	}
-	for i := float.start; i < float.stop; i += float.step {
-		arr << i
-	}
-	return arr
 }

--- a/range.v
+++ b/range.v
@@ -1,10 +1,10 @@
 module range
 
-pub struct Range[T] {
+struct Range[T] {
+mut:
 	limit T
 	step  T
-mut:
-	curr T
+	curr  T
 }
 
 fn (mut t Range[T]) next[T]() ?T {
@@ -16,24 +16,54 @@ fn (mut t Range[T]) next[T]() ?T {
 	return res
 }
 
-pub fn (mut t Range[T]) to_array[T]() []T {
+pub struct Builder[T] {
+pub:
+	from T
+	to   T
+	step T
+}
+
+pub fn (t Builder[T]) from(v T) Builder[T] {
+	return Builder[T]{
+		from: v
+		to: t.to
+		step: t.step
+	}
+}
+
+pub fn (t Builder[T]) to(v T) Builder[T] {
+	return Builder[T]{
+		from: t.from
+		to: v
+		step: t.step
+	}
+}
+
+pub fn (t Builder[T]) step(v T) Builder[T] {
+	return Builder[T]{
+		from: t.from
+		to: t.to
+		step: v
+	}
+}
+
+pub fn (t Builder[T]) iterator() Range[T] {
+	return Range[T]{
+		limit: t.to
+		step: t.step
+		curr: t.from
+	}
+}
+
+pub fn (t Builder[T]) array() []T {
 	mut res := []T{}
-	for v in t {
+	mut it := t.iterator()
+	for v in it {
 		res << v
 	}
 	return res
 }
 
-pub struct RangeOptions[T] {
-	start T
-	stop  T
-	step  T
-}
-
-pub fn range[T](opts RangeOptions[T]) Range[T] {
-	return Range[T]{
-		limit: opts.stop
-		step: opts.step
-		curr: opts.start
-	}
+pub fn new[T]() Builder[T] {
+	return Builder[T]{}
 }

--- a/range_test.v
+++ b/range_test.v
@@ -1,17 +1,54 @@
-import range
+module range
 
-// TODO: add more tests
-fn test_range() {
-	range.int({
-		stop: 10
-	}) == [0, 1, 2, 3, 4, 5, 6, 7, 8, 9]
-	range.int({
-		start: 1
-		stop: 10
-	}) == [1, 2, 3, 4, 5, 6, 7, 8, 9]
-	range.int({
-		start: 1
-		stop: 10
-		step: 2
-	}) == [1, 3, 5, 7, 9]
+fn assert_arrays_are_equal[T](expected []T, actual []T) {
+	assert expected.len == actual.len
+	for i := 0; i < expected.len; i++ {
+		assert expected[i] == actual[i], 'expected ${expected[i]} at index $[i] but got ${actual}'
+	}
+}
+
+fn test_all_args_inc_to_arr() {
+	start := 10
+	stop := 20
+	step := 2
+	expected := [10, 12, 14, 16, 18]
+	mut r := range(start: start, stop: stop, step: step)
+	assert start == r.curr
+	assert stop == r.limit
+	assert step == r.step
+	assert_arrays_are_equal(expected, r.to_array())
+}
+
+fn test_all_args_dec_to_arr() {
+	start := 20.0
+	stop := 10.0
+	step := -2.0
+	expected := [20.0, 18.0, 16.0, 14.0, 12.0]
+	mut r := range(start: start, stop: stop, step: step)
+	assert start == r.curr
+	assert stop == r.limit
+	assert step == r.step
+	assert_arrays_are_equal(expected, r.to_array())
+}
+
+fn test_no_start_inc_to_arr() {
+	stop := 10
+	step := 2
+	expected := [0, 2, 4, 6, 8]
+	mut r := range(stop: stop, step: step)
+	assert stop == r.limit
+	assert step == r.step
+	assert_arrays_are_equal(expected, r.to_array())
+}
+
+fn test_iterable() {
+	start := 0.0
+	step := 0.1
+	stop := 1.0 + step
+	mut expected := 0.0
+	mut r := range(start: start, stop: stop, step: step)
+	for actual in r {
+		assert actual == expected
+		expected += step
+	}
 }

--- a/range_test.v
+++ b/range_test.v
@@ -2,7 +2,7 @@ module range
 
 fn test_new_array_inc_int() {
 	expected := [0, 1, 2, 3, 4, 5, 6, 7, 8, 9]
-	actual := new[int]().from(0).to(10).step(1).array()
+	actual := new[int]().from(0).to(10).step(1).to_array()
 	assert actual == expected
 }
 
@@ -12,14 +12,14 @@ fn test_struct_array_inc_u8() {
 		from: 0
 		to: 10
 		step: 2
-	}.array()
+	}.to_array()
 	assert actual == expected
 }
 
 fn test_new_iterator_dec_f32() {
 	step := f32(0.1)
 	mut curr := f32(1.0)
-	iter := new[f32]().from(1.0).to(-step).step(-step).iterator()
+	iter := new[f32]().from(1.0).to(-step).step(-step).to_iterator()
 	for actual in iter {
 		assert actual == curr
 		curr -= step
@@ -33,7 +33,7 @@ fn test_struct_iterator_inc_f64() {
 		from: 0.0
 		to: 10
 		step: step
-	}.iterator()
+	}.to_iterator()
 	for actual in iter {
 		assert actual == curr
 		curr += step

--- a/range_test.v
+++ b/range_test.v
@@ -39,3 +39,19 @@ fn test_struct_iterator_inc_f64() {
 		curr += step
 	}
 }
+
+fn test_to_array_array_inc_int() {
+	expected := [0, 1, 2, 3, 4, 5, 6, 7, 8, 9]
+	actual := to_array(from: int(0), to: 10, step: 1)
+	assert actual == expected
+}
+
+fn test_to_iterator_iterator_dec_f32() {
+	step := f32(0.1)
+	mut curr := f32(1.0)
+	iter := to_iterator[f32](from: f32(1.0), to: -step, step: step)
+	for actual in iter {
+		assert actual == curr
+		curr -= step
+	}
+}

--- a/range_test.v
+++ b/range_test.v
@@ -1,54 +1,41 @@
 module range
 
-fn assert_arrays_are_equal[T](expected []T, actual []T) {
-	assert expected.len == actual.len
-	for i := 0; i < expected.len; i++ {
-		assert expected[i] == actual[i], 'expected ${expected[i]} at index $[i] but got ${actual}'
+fn test_new_array_inc_int() {
+	expected := [0, 1, 2, 3, 4, 5, 6, 7, 8, 9]
+	actual := new[int]().from(0).to(10).step(1).array()
+	assert actual == expected
+}
+
+fn test_struct_array_inc_u8() {
+	expected := [u8(0), 2, 4, 6, 8]
+	actual := Builder[u8]{
+		from: 0
+		to: 10
+		step: 2
+	}.array()
+	assert actual == expected
+}
+
+fn test_new_iterator_dec_f32() {
+	step := f32(0.1)
+	mut curr := f32(1.0)
+	iter := new[f32]().from(1.0).to(-step).step(-step).iterator()
+	for actual in iter {
+		assert actual == curr
+		curr -= step
 	}
 }
 
-fn test_all_args_inc_to_arr() {
-	start := 10
-	stop := 20
-	step := 2
-	expected := [10, 12, 14, 16, 18]
-	mut r := range(start: start, stop: stop, step: step)
-	assert start == r.curr
-	assert stop == r.limit
-	assert step == r.step
-	assert_arrays_are_equal(expected, r.to_array())
-}
-
-fn test_all_args_dec_to_arr() {
-	start := 20.0
-	stop := 10.0
-	step := -2.0
-	expected := [20.0, 18.0, 16.0, 14.0, 12.0]
-	mut r := range(start: start, stop: stop, step: step)
-	assert start == r.curr
-	assert stop == r.limit
-	assert step == r.step
-	assert_arrays_are_equal(expected, r.to_array())
-}
-
-fn test_no_start_inc_to_arr() {
-	stop := 10
-	step := 2
-	expected := [0, 2, 4, 6, 8]
-	mut r := range(stop: stop, step: step)
-	assert stop == r.limit
-	assert step == r.step
-	assert_arrays_are_equal(expected, r.to_array())
-}
-
-fn test_iterable() {
-	start := 0.0
-	step := 0.1
-	stop := 1.0 + step
-	mut expected := 0.0
-	mut r := range(start: start, stop: stop, step: step)
-	for actual in r {
-		assert actual == expected
-		expected += step
+fn test_struct_iterator_inc_f64() {
+	step := 3.1415
+	mut curr := 0.0
+	iter := Builder[f64]{
+		from: 0.0
+		to: 10
+		step: step
+	}.iterator()
+	for actual in iter {
+		assert actual == curr
+		curr += step
 	}
 }

--- a/v.mod
+++ b/v.mod
@@ -4,7 +4,7 @@ Module {
 	version: '0.0.3'
 	repo_url: 'https://github.com/Delta456/range'
 	vcs: 'git'
-	tags: ['range', 'python', 'vlang']
+	tags: ['range', 'vlang']
 	description: 'Functionality of Python's `range()` in V'
 	license: 'MIT'
 }


### PR DESCRIPTION
- Making the range into an iterator allow huge intervals to be used without using a lot of memory
- Making it generic allow the use of the other numeric data types